### PR TITLE
Align sponsors section with other content

### DIFF
--- a/app/views/pages/index.html.haml
+++ b/app/views/pages/index.html.haml
@@ -65,16 +65,16 @@
         %a{ href: "http://13wham.com/news/local/rit-hosts-annual-hack-a-thon" } RIT Hosts Local Hack-a-thon
       %li
         %a{ href: "http://www.rochesterfirst.com/news/local-news/rit-holds-wic-hacks-competition/663265505" } RIT holds WiC-hacks competition
-        #sponsors.divider
-        .section
-          %h2 Sponsors
-          %p
-            %b Is your company interested in sponsoring WiCHacks?
-            We would love to talk to you about sponsoring WiCHacks!
-            Please email
-            %a{ href: "mailto:wic.hacks.rit@gmail.com" } wic.hacks.rit@gmail.com
-            for more information.
-          %h6
-            = link_to '2018 Sponsor Information »', image_path('WiCHacksSponsorLetter18-1.pdf')
+  #sponsors.divider
+  .section
+    %h2 Sponsors
+    %p
+      %b Is your company interested in sponsoring WiCHacks?
+      We would love to talk to you about sponsoring WiCHacks!
+      Please email
+      %a{ href: "mailto:wic.hacks.rit@gmail.com" } wic.hacks.rit@gmail.com
+      for more information.
+    %h6
+      = link_to '2018 Sponsor Information »', image_path('WiCHacksSponsorLetter18-1.pdf')
 
 = render 'copyright'


### PR DESCRIPTION
The original sponsors section wasn't perfectly aligned with the rest of the sections, which wasn't easily seen until we removed the other content in #28 