### PR TITLE
Speed up Docker builds & fix support for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# All files should have regular lf line endings. Docker will break on Windows otherwise.
+* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 
 ADD Gemfile* /app/
 ADD .ruby-version /app/
+ADD vendor/cache /app/vendor/cache
 RUN gem install bundler
 RUN bundle install --jobs 20 --retry 5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,18 @@ RUN apt-get install -y libxml2-dev libxslt1-dev
 # for a JS runtime
 RUN apt-get install -y nodejs
 
-RUN mkdir /app
+RUN mkdir -p /app
 WORKDIR /app
+COPY . .
+# Add app files into docker image
 
-ADD Gemfile* /app/
-ADD .ruby-version /app/
-ADD vendor/cache /app/vendor/cache
-RUN gem install bundler
-RUN bundle install --jobs 20 --retry 5
+COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+# Add bundle entry point to handle bundle cache
 
-ADD . /app
+ENV BUNDLE_PATH=/bundle \
+    BUNDLE_BIN=/bundle/bin \
+    GEM_HOME=/bundle
+ENV PATH="${BUNDLE_BIN}:${PATH}"
+# Bundle installs with binstubs to our custom /bundle/bin volume path. Let system use those stubs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,18 @@ RUN apt-get install -y libxml2-dev libxslt1-dev
 # for a JS runtime
 RUN apt-get install -y nodejs
 
+# Add app files into docker image
 RUN mkdir -p /app
 WORKDIR /app
 COPY . .
-# Add app files into docker image
 
+# Add bundle entry point to handle bundle cache
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
-# Add bundle entry point to handle bundle cache
 
+# Bundle installs with binstubs to our custom /bundle/bin volume path. Let system use those stubs.
 ENV BUNDLE_PATH=/bundle \
     BUNDLE_BIN=/bundle/bin \
     GEM_HOME=/bundle
 ENV PATH="${BUNDLE_BIN}:${PATH}"
-# Bundle installs with binstubs to our custom /bundle/bin volume path. Let system use those stubs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - redis
     volumes:
       - .:/app
+      - bundle_cache:/bundle
     environment:
       - REDIS_URL=redis://redis:6379
 
@@ -29,5 +30,9 @@ services:
       - redis
     volumes:
       - .:/app
+      - bundle_cache:/bundle
     environment:
       - REDIS_URL=redis://redis:6379
+
+volumes:
+  bundle_cache:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Ensure we don't have two containers simultaneously running "bundle install"
+until [ ! -f .bundle-install-lock ]; do
+  >&2 echo "Another container is running 'bundle install' - sleeping"
+  sleep 5
+done
+
+touch .bundle-install-lock
+# Ensure all gems installed. Add binstubs to bin which has been added to PATH in Dockerfile.
+bundle check || bundle install --binstubs="$BUNDLE_BIN"
+rm .bundle-install-lock
+
+# Finally call command issued to the docker service
+exec "$@"


### PR DESCRIPTION
Originally committed this straight to develop, which ended up breaking things on Windows. This is because, by default, Git on Windows converts all line endings to Windows-style line endings (crlf). However, Docker doesn't always work with those Windows-formatted files.

This restores the changes I made to Docker, plus fixes support for Windows. Will be testing more to be sure before merging.

You may need to run `rm .git/index && git reset` if `docker-compose up --build` doesn't work at first