### PR TITLE
Reformat #pattern as a background-image instead of <img>

### DIFF
--- a/app/assets/stylesheets/splash.scss
+++ b/app/assets/stylesheets/splash.scss
@@ -83,10 +83,10 @@ h1, h2, h3, title, body {
   width: 100%;
 }
 
-#pattern {
+.pattern {
   bottom: 0;
   position: absolute;
-  background: url(splash-pattern.png) center top;
+  background: asset-url('splash-pattern.png') center top;
   background-size: cover;
   width: 100%;
   height: 200px;

--- a/app/assets/stylesheets/splash.scss
+++ b/app/assets/stylesheets/splash.scss
@@ -83,10 +83,13 @@ h1, h2, h3, title, body {
   width: 100%;
 }
 
-#pattern { 
-  bottom: -20%;
+#pattern {
+  bottom: 0;
   position: absolute;
-  background: none;
+  background: url(splash-pattern.png) center top;
+  background-size: cover;
+  width: 100%;
+  height: 200px;
 }
 
 /* small screen */

--- a/app/views/pages/splash.html.erb
+++ b/app/views/pages/splash.html.erb
@@ -51,7 +51,7 @@
 
     </div>
 
-    <%= image_tag("splash-pattern.png", class:"resize", id:"pattern") %>
-    
+    <div id="pattern"></div>
+
   </body>
 </html>

--- a/app/views/pages/splash.html.erb
+++ b/app/views/pages/splash.html.erb
@@ -51,7 +51,7 @@
 
     </div>
 
-    <div id="pattern"></div>
+    <div class="pattern"></div>
 
   </body>
 </html>


### PR DESCRIPTION
Uses a CSS `background:` for the pattern instead of an `<img>` tag. This lets us take advantage of the `background-size: cover` property, which mimics the behavior of a cover photo (such as on facebook or twitter) and works well for this use case.

This pull request is set to merge into the `splash` branch if merged