### PR TITLE
Add MLH badge to splash page

### DIFF
--- a/app/assets/stylesheets/splash.scss
+++ b/app/assets/stylesheets/splash.scss
@@ -154,7 +154,18 @@ html {
   height: 200px;
   background-repeat: repeat-x;
 
-  @media (max-height: 690px) {
+  // Prevent from blocking sign-up link
+  z-index: -1;
+
+  @media (min-width: 1200px) {
+    height: 300px;
+  }
+
+  @media (max-height: 700px) {
+    height: 150px;
+  }
+
+  @media (max-height: 480px) {
     position: relative;
     background-repeat: repeat-x;
   }

--- a/app/assets/stylesheets/splash.scss
+++ b/app/assets/stylesheets/splash.scss
@@ -66,7 +66,7 @@ html {
 }
 
 .inner-content {
-  padding-top: 80px;
+  padding-top: 120px;
   width: 800px;
 
   @media (max-width: 900px) {

--- a/app/views/pages/splash.html.erb
+++ b/app/views/pages/splash.html.erb
@@ -54,5 +54,6 @@
 
     <div class="pattern"></div>
 
+    <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:50px;position:fixed;right:20px;top:0;width:10%;z-index:10000" href="https://mlh.io/seasons/na-2018/events?utm_source=na-2018&utm_medium=TrustBadge&utm_campaign=na-2018&utm_content=white" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2018/white.svg" alt="Major League Hacking 2017 Hackathon Season" style="width:100%"></a>
   </body>
 </html>


### PR DESCRIPTION
Recently added the MLH badge on the old homepage, forgot to include it on the splash!

Also added a few more breakpoints to make the pattern fit better on super-small and super-big screens

Desktop:
![screenshot 2017-11-02 23 44 21](https://user-images.githubusercontent.com/1441807/32359954-eb48082a-c027-11e7-9ff2-eb9628207d78.png)


Mobile:
![screenshot 2017-11-02 23 44 42](https://user-images.githubusercontent.com/1441807/32359953-e9b117b8-c027-11e7-9352-62b559484fab.png)
