### PR TITLE
Use most recent Node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM ruby:2.5.1
 
 RUN apt-get update -qq && apt-get install -y build-essential
 
+# https://github.com/nodesource/distributions#installation-instructions
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+    && apt-get install -y nodejs
+
 # for mysql
 RUN apt-get install -y mysql-client
 


### PR DESCRIPTION
**Note:** be sure to `docker-compose build` before the next time you run `docker-compose up`

Includes the latest version of Node in the docker image (up from v4.8 to v10)